### PR TITLE
Add project homepage url to setup.cfg

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,7 @@
 [metadata]
 name = buzzoff
 version = attr: buzzoff.__version__
+url = https://github.com/spagh-eddie/buzzoff
 author = Eddie Darling
 author_email = darling@berkeley.edu
 maintainer = Eddie Darling


### PR DESCRIPTION
Hey @spagh-eddie, I found your project on PyPI because I'm planning to publish my own [package](https://github.com/JEHoctor/spelling-bee) related to NYT Spelling Bee. I've noticed that the homepage link on PyPI is often used to point to the GitHub repository (eg https://pypi.org/project/spelling-bee-mh/). I think this update to your `setup.cfg` will put a homepage link on your PyPI page, next time you upload a package.

Love the package name, btw!